### PR TITLE
feat: extend tool to create CSV equivalent to old Excel

### DIFF
--- a/ArtDecor2Excel.xsl
+++ b/ArtDecor2Excel.xsl
@@ -62,7 +62,10 @@
 
 <xsl:template name="additional_information">
 	<xsl:variable name="additionalInformationComment" select="comment[p[starts-with(normalize-space(.), 'Additional information:')]][1]/p[1]"/>
-	<xsl:value-of select="concat(substring-after(normalize-space($additionalInformationComment), 'Additional information: '), ';')"/>
+	<xsl:variable name="content">
+		<xsl:apply-templates select="$additionalInformationComment"/>
+	</xsl:variable>
+	<xsl:value-of select="concat($content, ';')"/>
 </xsl:template>
 
 <xsl:template name="short_input_help">

--- a/ArtDecor2Excel.xsl
+++ b/ArtDecor2Excel.xsl
@@ -53,11 +53,14 @@
 </xsl:template>
 
 <xsl:template name="heading">
-	<xsl:value-of select="concat(normalize-space(desc/p[1]),';')"/>
+	<xsl:value-of select="concat('&quot;', normalize-space(desc/p[1]),'&quot;;')"/>
 </xsl:template>
 
 <xsl:template name="description">
-	<xsl:value-of select="concat(substring-after(normalize-space(rationale/p[1]),'Description: '),';')"/>
+	<xsl:variable name="content">
+		<xsl:apply-templates select="rationale/p[1]"/>
+	</xsl:variable>
+	<xsl:value-of select="concat('&quot;', $content, '&quot;;')"/>
 </xsl:template>
 
 <xsl:template name="additional_information">
@@ -65,14 +68,14 @@
 	<xsl:variable name="content">
 		<xsl:apply-templates select="$additionalInformationComment"/>
 	</xsl:variable>
-	<xsl:value-of select="concat($content, ';')"/>
+	<xsl:value-of select="concat('&quot;', $content, '&quot;;')"/>
 </xsl:template>
 
 <xsl:template name="short_input_help">
 	<xsl:variable name="content">
-		<xsl:apply-templates select="operationalization/p[1]"/>
+		<xsl:apply-templates select="operationalization[1]/p[1]"/>
 	</xsl:variable>
-	<xsl:value-of select="concat($content, ';')"/>
+	<xsl:value-of select="concat('&quot;', $content, '&quot;;')"/>
 </xsl:template>
 
 <!-- Template for handling content of <p> elements -->
@@ -94,7 +97,7 @@
 </xsl:template>
 
 <xsl:template name="input_example">
-	<xsl:value-of select="normalize-space(valueDomain/example)"/>
+	<xsl:value-of select="concat('&quot;', normalize-space(valueDomain/example), '&quot;')"/>
 </xsl:template>
 
 <xsl:template match="concept[@statusCode='cancelled']" priority="1"/>

--- a/ArtDecor2Excel.xsl
+++ b/ArtDecor2Excel.xsl
@@ -18,7 +18,10 @@
 </xsl:template>
 
 <xsl:template name="cardinality">
-	<xsl:value-of select="concat(@minimumMultiplicity,'..',@maximumMultiplicity,';')"/>
+	<xsl:variable name="cardinalityComment" select="comment[p[starts-with(normalize-space(.), 'Cardinality:')]][1]/p[1]"/>
+	<!-- replace non-breaking spaces (&#160;) with regular spaces -->
+	<!-- (non-breaking spaces are not handled by normalize-space) -->
+	<xsl:value-of select="concat('&quot;', substring-after(normalize-space(translate($cardinalityComment, '&#160;', ' ')), 'Cardinality: '), '&quot;;')"/>
 </xsl:template>
 
 <!-- each code item on separate line - for excel: wrap all with quotes -->
@@ -77,6 +80,7 @@
 	<xsl:call-template name="item"/>
 	<xsl:value-of select="'BackboneElement;'"/>
 	<xsl:call-template name="cardinality"/>
+	<xsl:value-of select="'-;'"/>
 	<xsl:call-template name="heading"/>
 	<xsl:call-template name="description"/>
 	<xsl:call-template name="additional_information"/>

--- a/ArtDecor2Excel.xsl
+++ b/ArtDecor2Excel.xsl
@@ -91,7 +91,7 @@
 </xsl:template>
 
 <xsl:template name="input_example">
-	<xsl:value-of select="concat(normalize-space(valueDomain/example),';')"/>
+	<xsl:value-of select="normalize-space(valueDomain/example)"/>
 </xsl:template>
 
 <xsl:template match="concept[@statusCode='cancelled']" priority="1"/>

--- a/ArtDecor2Excel.xsl
+++ b/ArtDecor2Excel.xsl
@@ -12,7 +12,7 @@
 </xsl:text></xsl:variable>
 
 <xsl:template match="/dataset">
-	<xsl:text>No 3_3;Item;Data Type;Cardinality;Allowed Values;Data element heading || Short name to display (display_name);Data element description (description);Data element additional information - short input help (short_input_help);Data element additional information - input example (input_example)</xsl:text>
+	<xsl:text>No 3_3;Item;Data Type;Cardinality;Allowed Values;Data element heading || Short name to display (display_name);Data element description (description);Data element additional information - general information (additional_information);Data element additional information - short input help (short_input_help);Data element additional information - input example (input_example)</xsl:text>
 	<xsl:apply-templates select="concept">
 	</xsl:apply-templates>
 </xsl:template>
@@ -57,6 +57,11 @@
 	<xsl:value-of select="concat(substring-after(normalize-space(rationale/p[1]),'Description: '),';')"/>
 </xsl:template>
 
+<xsl:template name="additional_information">
+	<xsl:variable name="additionalInformationComment" select="comment[p[starts-with(normalize-space(.), 'Additional information:')]][1]/p[1]"/>
+	<xsl:value-of select="concat(substring-after(normalize-space($additionalInformationComment), 'Additional information: '), ';')"/>
+</xsl:template>
+
 <xsl:template name="short_input_help">
 	<xsl:value-of select="concat(substring-after(normalize-space(operationalization/p[1]),'Short input help: '),';')"/>
 </xsl:template>
@@ -74,6 +79,7 @@
 	<xsl:call-template name="cardinality"/>
 	<xsl:call-template name="heading"/>
 	<xsl:call-template name="description"/>
+	<xsl:call-template name="additional_information"/>
 	<xsl:call-template name="short_input_help"/>
 	<xsl:call-template name="input_example"/>
 	<xsl:apply-templates select="concept"/>
@@ -87,7 +93,7 @@
 			<xsl:value-of select="'CodeableConcept;'"/>
 			<xsl:call-template name="cardinality"/>
 			<xsl:call-template name="allowedValues"/>
-		</xsl:when >
+		</xsl:when>
 		<xsl:when test="valueDomain[@type='number' or @type='quantity']">
 			<xsl:value-of select="'integer;'"/>
 			<xsl:call-template name="cardinality"/>
@@ -101,6 +107,7 @@
 	</xsl:choose>
 	<xsl:call-template name="heading"/>
 	<xsl:call-template name="description"/>
+	<xsl:call-template name="additional_information"/>
 	<xsl:call-template name="short_input_help"/>
 	<xsl:call-template name="input_example"/>
 </xsl:template>

--- a/ArtDecor2Excel.xsl
+++ b/ArtDecor2Excel.xsl
@@ -66,7 +66,28 @@
 </xsl:template>
 
 <xsl:template name="short_input_help">
-	<xsl:value-of select="concat(substring-after(normalize-space(operationalization/p[1]),'Short input help: '),';')"/>
+	<xsl:variable name="content">
+		<xsl:apply-templates select="operationalization/p[1]"/>
+	</xsl:variable>
+	<xsl:value-of select="concat($content, ';')"/>
+</xsl:template>
+
+<!-- Template for handling content of <p> elements -->
+<xsl:template match="p">
+	<xsl:for-each select="node()">
+		<xsl:choose>
+			<xsl:when test="self::text()">
+				<xsl:value-of select="normalize-space(.)"/>
+			</xsl:when>
+			<xsl:when test="self::br">
+				<!-- Replace line breaks with spaces -->
+				<xsl:text> </xsl:text>
+			</xsl:when>
+			<xsl:otherwise>
+				<xsl:apply-templates select="node()"/>
+			</xsl:otherwise>
+		</xsl:choose>
+	</xsl:for-each>
 </xsl:template>
 
 <xsl:template name="input_example">

--- a/ArtDecor2Excel.xsl
+++ b/ArtDecor2Excel.xsl
@@ -12,7 +12,7 @@
 </xsl:text></xsl:variable>
 
 <xsl:template match="/dataset">
-	<xsl:text>No 3_3;Item;Data Type;Cardinality;Allowed Values;Data element heading || Short name to display (display_name);Data element description (description)</xsl:text>
+	<xsl:text>No 3_3;Item;Data Type;Cardinality;Allowed Values;Data element heading || Short name to display (display_name);Data element description (description);Data element additional information - short input help (short_input_help);Data element additional information - input example (input_example)</xsl:text>
 	<xsl:apply-templates select="concept">
 	</xsl:apply-templates>
 </xsl:template>
@@ -57,6 +57,14 @@
 	<xsl:value-of select="concat(substring-after(normalize-space(rationale/p[1]),'Description: '),';')"/>
 </xsl:template>
 
+<xsl:template name="short_input_help">
+	<xsl:value-of select="concat(substring-after(normalize-space(operationalization/p[1]),'Short input help: '),';')"/>
+</xsl:template>
+
+<xsl:template name="input_example">
+	<xsl:value-of select="concat(normalize-space(valueDomain/example),';')"/>
+</xsl:template>
+
 <xsl:template match="concept[@statusCode='cancelled']" priority="1"/>
 
 <xsl:template match="concept[@type='group']">
@@ -66,6 +74,8 @@
 	<xsl:call-template name="cardinality"/>
 	<xsl:call-template name="heading"/>
 	<xsl:call-template name="description"/>
+	<xsl:call-template name="short_input_help"/>
+	<xsl:call-template name="input_example"/>
 	<xsl:apply-templates select="concept"/>
 </xsl:template>
 
@@ -91,6 +101,8 @@
 	</xsl:choose>
 	<xsl:call-template name="heading"/>
 	<xsl:call-template name="description"/>
+	<xsl:call-template name="short_input_help"/>
+	<xsl:call-template name="input_example"/>
 </xsl:template>
 
 </xsl:stylesheet>

--- a/makefile
+++ b/makefile
@@ -1,4 +1,6 @@
-all: Design.csv MDS_V3_3.csv 
+CSV_FILES = Core.csv Design.csv NutritionalEpidemiology.csv ChronicDiseases.csv RecordLinkage.csv
+
+all: MDS_V3_3.csv Design.csv Core.csv RecordLinkage.csv NutritionalEpidemiology.csv ChronicDiseases.csv
 
 CoreMDS33.xml:
 	wget 'http://art-decor.org/decor/services/RetrieveTransaction?id=2.16.840.1.113883.3.1937.777.64.4.4&effectiveDate=2023-11-28T00%3A00%3A00&language=en-US&ui=de-DE&format=xml' -O $@
@@ -6,17 +8,41 @@ CoreMDS33.xml:
 Design33.xml:
 	wget 'http://art-decor.org/decor/services/RetrieveTransaction?id=2.16.840.1.113883.3.1937.777.64.4.8&effectiveDate=2023-12-21T00%3A00%3A00&language=en-US&ui=de-DE&format=xml' -O $@
 
+RecordLinkage33.xml:
+	wget 'https://art-decor.org/decor/services/RetrieveTransaction?id=2.16.840.1.113883.3.1937.777.64.4.6&format=xml' -O $@
+
+NutritionalEpidemiology33.xml:
+	wget 'https://art-decor.org/decor/services/RetrieveTransaction?id=2.16.840.1.113883.3.1937.777.64.4.10&format=xml' -O $@
+
+ChronicDiseases33.xml:
+	wget 'https://art-decor.org/decor/services/RetrieveTransaction?id=2.16.840.1.113883.3.1937.777.64.4.12&format=xml' -O $@
+
 clean: 
-	rm -f Design.csv MDS_V3_3.csv
+	rm -f $(CSV_FILES)
 
 distclean: clean
-	rm -f CoreMDS33.xml Design33.xml Saxon-HE-12.4.jar xmlresolver-6.0.4.jar
+	rm -f CoreMDS33.xml Design33.xml RecordLinkage33.xml NutritionalEpidemiology33.xml ChronicDiseases33.xml Saxon-HE-12.4.jar xmlresolver-6.0.4.jar
 
 Design.csv: Design33.xml ArtDecor2Excel.xsl Saxon-HE-12.4.jar xmlresolver-6.0.4.jar
 	java -cp "*" net.sf.saxon.Transform -xsl:ArtDecor2Excel.xsl -s:$< -o:$@
 
-MDS_V3_3.csv: CoreMDS33.xml ArtDecor2Excel.xsl Saxon-HE-12.4.jar xmlresolver-6.0.4.jar
+Core.csv: CoreMDS33.xml ArtDecor2Excel.xsl Saxon-HE-12.4.jar xmlresolver-6.0.4.jar
 	java -cp "*" net.sf.saxon.Transform -xsl:ArtDecor2Excel.xsl -s:$< -o:$@
+
+RecordLinkage.csv: RecordLinkage33.xml ArtDecor2Excel.xsl Saxon-HE-12.4.jar xmlresolver-6.0.4.jar
+	java -cp "*" net.sf.saxon.Transform -xsl:ArtDecor2Excel.xsl -s:$< -o:$@
+
+NutritionalEpidemiology.csv: NutritionalEpidemiology33.xml ArtDecor2Excel.xsl Saxon-HE-12.4.jar xmlresolver-6.0.4.jar
+	java -cp "*" net.sf.saxon.Transform -xsl:ArtDecor2Excel.xsl -s:$< -o:$@
+
+ChronicDiseases.csv: ChronicDiseases33.xml ArtDecor2Excel.xsl Saxon-HE-12.4.jar xmlresolver-6.0.4.jar
+	java -cp "*" net.sf.saxon.Transform -xsl:ArtDecor2Excel.xsl -s:$< -o:$@
+
+MDS_V3_3.csv: $(CSV_FILES)
+	head -n 1 Core.csv > $@
+	for file in $(CSV_FILES); do \
+		tail -n+2 $$file && echo ""; \
+	done >> $@
 
 Saxon-HE-12.4.jar:
 	mvn dependency:copy -Dartifact=net.sf.saxon:Saxon-HE:12.4 -DoutputDirectory=.


### PR DESCRIPTION
This adds several improvements/extensions to the tool to create a CSV which contains all information equivalent to the old Exel file:

* extracts additional_information and conditional cardinalities
* adds use case metadata blocks
* creates a CSV file for each block, but also one combined CSV file containing all blocks (Core + Design + UCs)
* fixes problems caused by line breaks, semicolons and duplicated XML tags